### PR TITLE
Remove namespace lookup

### DIFF
--- a/kubectl-exec-as
+++ b/kubectl-exec-as
@@ -41,30 +41,29 @@ USERNAME="${USERNAME:-root}"
 echo -e "\nConnecting...\nPod: ${POD}\nUser: ${USERNAME}\nContainer:$CONTAINER\nCommand:$COMMAND\n"
 
 KUBECTL=$(which kubectl)
-NAMESPACE=$(kubectl config view --template='{{ range .contexts }}{{ if eq .name "'$(kubectl config current-context)'" }}{{ .context.namespace }}{{ end }}{{ end }}')
 
 # Limits concurrent sessions (each session deploys a pod) to 2. It's not necessary, just a preference.
-test "$(exec kubectl get po "$(whoami)-1" 2>/dev/null)" && container="$(whoami)-2" || container="$(whoami)-1"
+test "$(exec $KUBECTL get po "$(whoami)-1" 2>/dev/null)" && container="$(whoami)-2" || container="$(whoami)-1"
 
 # We want to mount the docker socket on the node of the pod we're exec'ing into.
-NODENAME=$( ${KUBECTL} --namespace ${NAMESPACE} get pod ${POD} -o go-template='{{.spec.nodeName}}' )
+NODENAME=$( ${KUBECTL} get pod ${POD} -o go-template='{{.spec.nodeName}}' )
 NODESELECTOR='"nodeSelector": {"kubernetes.io/hostname": "'$NODENAME'"},'
 
 # Adds toleration if the target container runs on a tainted node. Assumes no more than one taint. Change if yours have more than one or are configured differently.
-TOLERATION_VALUE=$($KUBECTL --namespace ${NAMESPACE} get pod ${POD} -ojsonpath='{.spec.tolerations[].value}') >/dev/null 2>&1
+TOLERATION_VALUE=$($KUBECTL get pod ${POD} -ojsonpath='{.spec.tolerations[].value}') >/dev/null 2>&1
 if [[ "$TOLERATION_VALUE" ]]; then
-    TOLERATION_KEY=$($KUBECTL --namespace ${NAMESPACE} get pod ${POD} -ojsonpath='{.spec.tolerations[].key}')
-    TOLERATION_OPERATOR=$($KUBECTL --namespace ${NAMESPACE} get pod ${POD} -ojsonpath='{.spec.tolerations[].operator}')
-    TOLERATION_EFFECT=$($KUBECTL --namespace ${NAMESPACE} get pod ${POD} -ojsonpath='{.spec.tolerations[].effect}')
+    TOLERATION_KEY=$($KUBECTL get pod ${POD} -ojsonpath='{.spec.tolerations[].key}')
+    TOLERATION_OPERATOR=$($KUBECTL get pod ${POD} -ojsonpath='{.spec.tolerations[].operator}')
+    TOLERATION_EFFECT=$($KUBECTL get pod ${POD} -ojsonpath='{.spec.tolerations[].effect}')
     TOLERATIONS='"tolerations": [{"effect": "'$TOLERATION_EFFECT'","key": "'$TOLERATION_KEY'","operator": "'$TOLERATION_OPERATOR'","value": "'$TOLERATION_VALUE'"}],'
 else
     TOLERATIONS=''
 fi
 
 if [[ -n ${CONTAINER} ]]; then
-  DOCKER_CONTAINERID=$( eval $KUBECTL --namespace ${NAMESPACE} get pod ${POD} -o go-template="'{{ range .status.containerStatuses }}{{ if eq .name \"${CONTAINER}\" }}{{ .containerID }}{{ end }}{{ end }}'" )
+  DOCKER_CONTAINERID=$( eval $KUBECTL get pod ${POD} -o go-template="'{{ range .status.containerStatuses }}{{ if eq .name \"${CONTAINER}\" }}{{ .containerID }}{{ end }}{{ end }}'" )
 else
-  DOCKER_CONTAINERID=$( $KUBECTL --namespace ${NAMESPACE} get pod ${POD} -o go-template='{{ (index .status.containerStatuses 0).containerID }}' )
+  DOCKER_CONTAINERID=$( $KUBECTL get pod ${POD} -o go-template='{{ (index .status.containerStatuses 0).containerID }}' )
 fi
 CONTAINERID=${DOCKER_CONTAINERID#*//}
 
@@ -114,4 +113,4 @@ read -r -d '' OVERRIDES <<EOF
 }
 EOF
 
-eval kubectl run -it --restart=Never --image=docker --overrides="'${OVERRIDES}'" $container
+eval $KUBECTL run -it --restart=Never --image=docker --overrides="'${OVERRIDES}'" $container


### PR DESCRIPTION
Removes namespace lookup.  Because the plugin does not traverse namespaces, it appears unnecessary.