### PR TITLE
add more privileges for kubectl ssh

### DIFF
--- a/kubectl-ssh
+++ b/kubectl-ssh
@@ -81,6 +81,7 @@ read -r -d '' OVERRIDES <<EOF
                 "restartPolicy": "Never",
                 "args": [
                   "exec",
+                  "--privileged",
                   "-it",
                   "-u",
                   "${USERNAME}",


### PR DESCRIPTION
## Checklist

1) Adresses Issue: noup
We have an issue with `kubectl ssh`. Dev tools like `lsof` don't work well :

```
# lsof -p 1
COMMAND PID USER   FD      TYPE DEVICE SIZE/OFF NODE NAME
java      1  app  cwd   unknown                      /proc/1/cwd (readlink: Permission denied)
java      1  app  rtd   unknown                      /proc/1/root (readlink: Permission denied)
java      1  app  txt   unknown                      /proc/1/exe (readlink: Permission denied)
java      1  app    0   unknown                      /proc/1/fd/0 (readlink: Permission denied)
java      1  app    1   unknown                      /proc/1/fd/1 (readlink: Permission denied)
java      1  app    2   unknown                      /proc/1/fd/2 (readlink: Permission denied)
java      1  app    3   unknown                      /proc/1/fd/3 (readlink: Permission denied)
```
```
# ls -al /proc/1/fd 2>&1 | head -10
ls: cannot read symbolic link '/proc/1/fd/0': Permission denied
ls: cannot read symbolic link '/proc/1/fd/1': Permission denied
ls: cannot read symbolic link '/proc/1/fd/2': Permission denied
ls: cannot read symbolic link '/proc/1/fd/3': Permission denied
ls: cannot read symbolic link '/proc/1/fd/4': Permission denied
ls: cannot read symbolic link '/proc/1/fd/5': Permission denied
ls: cannot read symbolic link '/proc/1/fd/6': Permission denied
ls: cannot read symbolic link '/proc/1/fd/7': Permission denied
ls: cannot read symbolic link '/proc/1/fd/8': Permission denied
ls: cannot read symbolic link '/proc/1/fd/9': Permission denied
```

When I add --privileged, it works file:

```
# ls -la /proc/1/fd | head
total 0
dr-x------ 2 app app  0 Jun 27 12:08 .
dr-xr-xr-x 9 app app  0 Jun 27 12:08 ..
lr-x------ 1 app app 64 Jun 27 12:08 0 -> pipe:[3807969]
l-wx------ 1 app app 64 Jun 27 12:08 1 -> pipe:[3807970]
lrwx------ 1 app app 64 Jun 27 13:33 10 -> socket:[3804006]
lrwx------ 1 app app 64 Jun 27 13:33 100 -> anon_inode:[eventpoll]
lrwx------ 1 app app 64 Jun 27 13:33 1000 -> anon_inode:[eventpoll]
lr-x------ 1 app app 64 Jun 27 13:33 10000 -> pipe:[5579567]
l-wx------ 1 app app 64 Jun 27 13:33 10001 -> pipe:[5579567]
```

```
# lsof -p 1 | head
COMMAND PID USER   FD      TYPE             DEVICE  SIZE/OFF     NODE NAME
java      1  app  cwd       DIR              0,342      4096  4447952 /app
java      1  app  rtd       DIR              0,342      4096  4448151 /
java      1  app  txt       REG              0,342     10544  2877770 /usr/lib/jvm/java-11-openjdk-amd64/bin/java
java      1  app  mem       REG                8,1            2878031 /usr/lib/jvm/java-11-openjdk-amd64/lib/server/classes.jsa (path dev=0,342)
java      1  app  mem       REG                8,1            2877770 /usr/lib/jvm/java-11-openjdk-amd64/bin/java (path dev=0,342)
java      1  app  mem       REG                8,1            2878017 /usr/lib/jvm/java-11-openjdk-amd64/lib/libsunec.so (path dev=0,342)
java      1  app  mem       REG                8,1            2872808 /lib/x86_64-linux-gnu/libresolv-2.24.so (path dev=0,342)
java      1  app  mem       REG                8,1            2872787 /lib/x86_64-linux-gnu/libnss_dns-2.24.so (path dev=0,342)
java      1  app  mem       REG                8,1            2877992 /usr/lib/jvm/java-11-openjdk-amd64/lib/libextnet.so (path dev=0,342)
```

2) Quick summary of changes
add more privileges for kubectl ssh
3) Changes are GNU/BSD Compatable: yes
4) Changes are applicable to the wider community: yes
5) Request help with testing if needed: noup

