### PR TITLE
code refactoring of kubectl-ssh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,18 @@ ex '+g/KUBECTL_\(.*\)_PROMPT/d' -cwq ~/.bash_profile
 ![kapssh](https://user-images.githubusercontent.com/22456127/46683069-4152c100-cbbd-11e8-9db5-9fb319bb320b.gif)
 - Like kubectl exec, but offers a --user flag to exec as root (or any other user)
 - 'ssh' is a misnomer (it works by mounting a docker socket as a volume), but it's easier to work with as a command.
-- You must be in the same namespace as the target pod (passing ```-n namespace``` is not currently allowed).
+- You must be in the same namespace as the target pod or you can use ```-n namespace``` option to specify the namespace
 - Kudos to mikelorant for thinking of the docker socket! :)
+
+Usage: ```kubectl ssh [OPTIONS] <pod name> [-- <commands...>]```
 
 Option | Required | Description | Example
 ------------- | ------------- | ------------- | -------------
 -h | N | Show usage | *`kubectl ssh -h`*
--p | Y | Pod name. The `-p` flag can be omitted if no other flags are passed (i.e., `kubectl ssh kafka-0`)| *`kubectl -p kafka-0`*
--u | N | User to exec as. Defaults to root | *`kubectl ssh -u kafka -p kafka-0`*
--c | N | Specify container within pod | *`kubectl ssh -c burrow-metrics -p kafka-0`*
+-d | N | Enable debug mode. Print a trace of each commands |  *`kubectl ssh -d kafka-0`*
+-n | N | The namespace scope for this CLI request | *`kubectl ssh -n infra kafka-0`*
+-u | N | User to exec as. Defaults to root | *`kubectl ssh -u kafka kafka-0`*
+-c | N | Specify container within pod | *`kubectl ssh -c burrow-metrics kafka-0`*
 -- | N | Pass an optional command. Defaults to /bin/sh | *`kubectl ssh kafka -- ls /etc/burrow`*
 
 

--- a/kubectl-ssh
+++ b/kubectl-ssh
@@ -1,73 +1,116 @@
 #!/usr/bin/env bash
 
-trap 'kubectl delete pod $container >/dev/null 2>&1 &' 0 1 2 3 15
+set -eu
 
-usage() { echo -e "Usage: kubectl ssh <options> <pod name>" && grep " .)\ #" $0; exit 0; }
+usage() {
+  cat <<EOF
+
+Usage: kubectl ssh [OPTIONS] <pod name> [-- <commands...>]
+
+Run a command in a running container
+
+Options:
+  -h  Show usage
+  -d  Enable debug mode. Print a trace of each commands
+  -n  If present, the namespace scope for this CLI request
+  -u  Username or UID (format: <name|uid>[:<group|gid>])
+  -c  Container name. If omitted, the first container in the pod will be chosen
+EOF
+  exit 0
+}
+
+to_json() {
+  text="$*"
+  p=""
+  for i in $text; do
+    [[ -n "$p" ]] && p+=", "
+    p+="\"$i"\"
+  done
+  echo -en "$p"
+}
+
+
 [ $# -eq 0 ] && usage
 
-while getopts ":u:c:p:h" arg; do
- case $arg in
-   p) # Specify pod name.
-     POD=${OPTARG}
-     ;;
-   u) # Specify user
-     USERNAME=${OPTARG}
-     ;;
-   c) # Specify container
-     CONTAINER=${OPTARG}
-     ;;
-   h) # Display help.
-     usage
-     exit 0
-     ;;
-   -- ) # Optional command to execute. Defaults to /bin/sh
-     ;;
-   *)
-     ;;
- esac
+KUBECTL="$(type -p kubectl)"
+COMMAND="/bin/sh"
+USERNAME="root"
+CONTAINER="NONE"
+NAMESPACE="NONE"
+
+while getopts "dh:p:n:u:c" arg; do
+  case $arg in
+    p) # Specify pod name.
+      POD=${OPTARG}
+      ;;
+    n) # Specify namespace
+      NAMESPACE=${OPTARG}
+      KUBECTL+=" --namespace=${OPTARG}"
+      ;;
+    u) # Specify user
+      USERNAME=${OPTARG}
+      ;;
+    c) # Specify container
+      CONTAINER=${OPTARG}
+      ;;
+    d) # Enable debug mode
+      set -x
+      ;;
+    h) # Display help.
+      usage
+      ;;
+    \?)
+      usage
+      ;;
+  esac
 done
 
-COMMAND=$(echo $@ | grep '\-\-' | sed 's|\(.*\) -- \(.*\)|\2|g')
-COMMAND="${COMMAND:-/bin/sh}"
+shift $((OPTIND-1))
+if [[ -z ${1+x} ]]; then
+  echo "Error: You have to specify the pod name" >&2
+  usage
+fi
+POD="$1"
+shift
 
-if [ -z "$POD" ] && [ -z "$CONTAINER" ] && [ -z "$USERNAME" ]; then
-   POD="$1"
+if [[ $# -gt 0 ]]; then
+  if [[ $1 == "--" ]]; then
+    shift
+    COMMAND="$*"
+  else
+    echo "Error: Invalid option: $0" >&2
+    usage
+  fi
 fi
 
-USERNAME="${USERNAME:-root}"
-
-[ -z $POD ] && echo -e "\nMissing Pod Name" && exit 1
-
-echo -e "\nConnecting...\nPod: ${POD}\nUser: ${USERNAME}\nContainer:$CONTAINER\nCommand:$COMMAND\n"
-
-KUBECTL=$(which kubectl)
+echo -e "\nConnecting...\nPod: ${POD}\nNamespace: ${NAMESPACE}\nUser: ${USERNAME}\nContainer: ${CONTAINER}\nCommand: $COMMAND\n"
 
 # Limits concurrent sessions (each session deploys a pod) to 2. It's not necessary, just a preference.
-test "$(exec $KUBECTL get po "$(whoami)-1" 2>/dev/null)" && container="$(whoami)-2" || container="$(whoami)-1"
+test "$(exec "${KUBECTL}" get po "$(whoami)-1" 2>/dev/null)" && container="$(whoami)-2" || container="$(whoami)-1"
 
 # We want to mount the docker socket on the node of the pod we're exec'ing into.
-NODENAME=$( ${KUBECTL} get pod ${POD} -o go-template='{{.spec.nodeName}}' )
+NODENAME=$( ${KUBECTL} get pod "${POD}" -o go-template='{{.spec.nodeName}}' )
 NODESELECTOR='"nodeSelector": {"kubernetes.io/hostname": "'$NODENAME'"},'
 
 # Adds toleration if the target container runs on a tainted node. Assumes no more than one taint. Change if yours have more than one or are configured differently.
-TOLERATION_VALUE=$($KUBECTL get pod ${POD} -ojsonpath='{.spec.tolerations[].value}') >/dev/null 2>&1
+TOLERATION_VALUE=$($KUBECTL get pod "${POD}" -ojsonpath='{.spec.tolerations[].value}') >/dev/null 2>&1
 if [[ "$TOLERATION_VALUE" ]]; then
-    TOLERATION_KEY=$($KUBECTL get pod ${POD} -ojsonpath='{.spec.tolerations[].key}')
-    TOLERATION_OPERATOR=$($KUBECTL get pod ${POD} -ojsonpath='{.spec.tolerations[].operator}')
-    TOLERATION_EFFECT=$($KUBECTL get pod ${POD} -ojsonpath='{.spec.tolerations[].effect}')
-    TOLERATIONS='"tolerations": [{"effect": "'$TOLERATION_EFFECT'","key": "'$TOLERATION_KEY'","operator": "'$TOLERATION_OPERATOR'","value": "'$TOLERATION_VALUE'"}],'
+  TOLERATION_KEY=$($KUBECTL get pod "${POD}" -ojsonpath='{.spec.tolerations[].key}')
+  TOLERATION_OPERATOR=$($KUBECTL get pod "${POD}" -ojsonpath='{.spec.tolerations[].operator}')
+  TOLERATION_EFFECT=$($KUBECTL get pod "${POD}" -ojsonpath='{.spec.tolerations[].effect}')
+  TOLERATIONS='"tolerations": [{"effect": "'$TOLERATION_EFFECT'","key": "'$TOLERATION_KEY'","operator": "'$TOLERATION_OPERATOR'","value": "'$TOLERATION_VALUE'"}],'
 else
     TOLERATIONS=''
 fi
 
-if [[ -n ${CONTAINER} ]]; then
-  DOCKER_CONTAINERID=$( eval $KUBECTL get pod ${POD} -o go-template="'{{ range .status.containerStatuses }}{{ if eq .name \"${CONTAINER}\" }}{{ .containerID }}{{ end }}{{ end }}'" )
+if [[ ${CONTAINER} != "NONE" ]]; then
+  DOCKER_CONTAINERID=$( eval "$KUBECTL" get pod "${POD}" -o go-template="'{{ range .status.containerStatuses }}{{ if eq .name \"${CONTAINER}\" }}{{ .containerID }}{{ end }}{{ end }}'" )
 else
-  DOCKER_CONTAINERID=$( $KUBECTL get pod ${POD} -o go-template='{{ (index .status.containerStatuses 0).containerID }}' )
+  DOCKER_CONTAINERID=$( $KUBECTL get pod "${POD}" -o go-template='{{ (index .status.containerStatuses 0).containerID }}' )
 fi
 CONTAINERID=${DOCKER_CONTAINERID#*//}
 
-read -r -d '' OVERRIDES <<EOF
+read -r -d '' OVERRIDES <<EOF || :
 {
     "apiVersion": "v1",
     "spec": {
@@ -86,7 +129,7 @@ read -r -d '' OVERRIDES <<EOF
                   "-u",
                   "${USERNAME}",
                   "${CONTAINERID}",
-                  "${COMMAND}"
+                  $(to_json "${COMMAND}")
                 ],
                 "volumeMounts": [
                     {
@@ -114,4 +157,6 @@ read -r -d '' OVERRIDES <<EOF
 }
 EOF
 
-eval $KUBECTL run -it --restart=Never --image=docker --overrides="'${OVERRIDES}'" $container
+trap '$KUBECTL delete pod $container >/dev/null 2>&1 &' 0 1 2 3 15
+
+eval "$KUBECTL" run -it --restart=Never --image=docker --overrides="'${OVERRIDES}'" "$container"


### PR DESCRIPTION
## Checklist

1) Adresses Issue: NONE
2) Quick summary of changes
I've made code refactoring of `kubectl ssh`:
- add more strict error handling for variables and commands `set -eu`
- add debug mode
- add options to specify the namespace
- add ability to specify commands with args
- fix all BASH linter warnings
- remove `-p` option, we do not need to use it anymore to specify the pod name with additional options  
3) Changes are GNU/BSD Compatable: yes
4) Changes are applicable to the wider community: yup
5) Request help with testing if needed: please test if you can

