### PR TITLE
kubectl-ssh: fix whoami usage for usernames with special characters

### DIFF
--- a/kubectl-ssh
+++ b/kubectl-ssh
@@ -86,7 +86,7 @@ fi
 echo -e "\nConnecting...\nPod: ${POD}\nNamespace: ${NAMESPACE}\nUser: ${USERNAME}\nContainer: ${CONTAINER}\nCommand: $COMMAND\n"
 
 # Limits concurrent sessions (each session deploys a pod) to 2. It's not necessary, just a preference.
-test "$(exec "${KUBECTL}" get po "$(whoami)-1" 2>/dev/null)" && container="$(whoami)-2" || container="$(whoami)-1"
+test "$(exec "${KUBECTL}" get po "$(whoami|tr -dc '[:alnum:]')-1" 2>/dev/null)" && container="$(whoami|tr -dc '[:alnum:]')-2" || container="$(whoami|tr -dc '[:alnum:]')-1"
 
 # We want to mount the docker socket on the node of the pod we're exec'ing into.
 NODENAME=$( ${KUBECTL} get pod "${POD}" -o go-template='{{.spec.nodeName}}' )


### PR DESCRIPTION
This fix is for kubectl-ssh. I adjusted the usage of the whoami command, which is used to define the pod name. My username has a dot in it which let the command fail with the error message:
```The Pod "stefan.kirrmann-1" is invalid: spec.containers[0].name: Invalid value: "stefan.kirrmann-1": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')```
