### PR TITLE
Remove type field for docker.sock volume

### DIFF
--- a/kubectl-ssh
+++ b/kubectl-ssh
@@ -147,8 +147,7 @@ read -r -d '' OVERRIDES <<EOF || :
             {
                 "name": "docker",
                 "hostPath": {
-                    "path": "/var/run/docker.sock",
-                    "type": "File"
+                    "path": "/var/run/docker.sock"
                 }
             }
         ]


### PR DESCRIPTION
Fixes kubectl-ssh plugin.
Resolves issue #34 #31 
