### PR TITLE
Prevent istio to be injected in the ssh-pod

### DIFF
--- a/kubectl-ssh
+++ b/kubectl-ssh
@@ -112,6 +112,11 @@ CONTAINERID=${DOCKER_CONTAINERID#*//}
 read -r -d '' OVERRIDES <<EOF || :
 {
     "apiVersion": "v1",
+    "metadata": {
+      "annotations": {
+        "sidecar.istio.io/inject" : "false"
+      }
+    },
     "spec": {
         "containers": [
             {


### PR DESCRIPTION
Without this annotation, an istio container is injected, and it's the first container of the pod. This script try to connect to it.
This annotation doesn't change any behavior in a cluster without istio.
Fix #32 
