### PR TITLE
 Fix not working exec-as plugin on newer kubernetes clusters

### DIFF
--- a/kubectl-exec-as
+++ b/kubectl-exec-as
@@ -113,6 +113,7 @@ read -r -d '' OVERRIDES <<EOF || :
 {
     "apiVersion": "v1",
     "spec": {
+        "securityContext": { "runAsUser": 0 },
         "containers": [
             {
                 "image": "docker",

--- a/kubectl-exec-as
+++ b/kubectl-exec-as
@@ -112,6 +112,11 @@ CONTAINERID=${DOCKER_CONTAINERID#*//}
 read -r -d '' OVERRIDES <<EOF || :
 {
     "apiVersion": "v1",
+    "metadata": {
+      "annotations": {
+        "sidecar.istio.io/inject" : "false"
+      }
+    },
     "spec": {
         "securityContext": { "runAsUser": 0 },
         "containers": [
@@ -127,7 +132,7 @@ read -r -d '' OVERRIDES <<EOF || :
                   "--privileged",
                   "-it",
                   "-u",
-                  "${USERNAME}",
+                  "${UID}",
                   "${CONTAINERID}",
                   $(to_json "${COMMAND}")
                 ],
@@ -148,8 +153,7 @@ read -r -d '' OVERRIDES <<EOF || :
             {
                 "name": "docker",
                 "hostPath": {
-                    "path": "/var/run/docker.sock",
-                    "type": "File"
+                    "path": "/var/run/docker.sock"
                 }
             }
         ]

--- a/kubectl-exec-as
+++ b/kubectl-exec-as
@@ -132,7 +132,7 @@ read -r -d '' OVERRIDES <<EOF || :
                   "--privileged",
                   "-it",
                   "-u",
-                  "${UID}",
+                  "${USERNAME}",
                   "${CONTAINERID}",
                   $(to_json "${COMMAND}")
                 ],


### PR DESCRIPTION
Fixes the ssh plugin that's not working on newer kubernetes clusters by adding securityContext.

Please test if this breaks anything for you.